### PR TITLE
Additions to performance PR

### DIFF
--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionMapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.Equipment;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
+using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
 using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 
@@ -30,17 +31,50 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                                           IEnumerable<string> isoDeviceElementIDs,
                                           Dictionary<string, List<ISOProductAllocation>> isoProductAllocations)
         {
+            var usedDataLogValues = new List<ISODataLogValue>();
+
+            foreach (string isoDeviceElementID in isoDeviceElementIDs)
+            {
+                DeviceHierarchyElement hierarchyElement = TaskDataMapper.DeviceElementHierarchies.GetMatchingElement(isoDeviceElementID);
+                int? adaptDeviceElementId = TaskDataMapper.InstanceIDMap.GetADAPTID(isoDeviceElementID);
+                if (hierarchyElement != null &&
+                    adaptDeviceElementId.HasValue &&
+                    DataModel.Catalog.DeviceElements.Any(d => d.Id.ReferenceId == adaptDeviceElementId.Value))
+                { 
+                    usedDataLogValues.AddRange(_workingDataMapper.GetDataLogValuesForDeviceElement(time, hierarchyElement));
+                }
+            }
+
+            List<ISOSpatialRow> isoRecordsWithData = new List<ISOSpatialRow>();
+            if (usedDataLogValues.Any())
+            {
+                foreach (var isoRecord in isoRecords)
+                {
+                    int beforeCount = usedDataLogValues.Count;
+                    var notReferencedDataLogValues = usedDataLogValues.Where(x =>
+                        !isoRecord.SpatialValues.Any(y => y.DataLogValue.ProcessDataIntDDI == x.ProcessDataIntDDI &&
+                                                          y.DataLogValue.DeviceElementIdRef.ReverseEquals(x.DeviceElementIdRef)));
+                    usedDataLogValues = notReferencedDataLogValues.ToList();
+                    if (beforeCount != usedDataLogValues.Count)
+                    {
+                        isoRecordsWithData.Add(isoRecord);
+                    }
+                    if (usedDataLogValues.Count == 0)
+                    {
+                        break;
+                    }
+                }
+            }
+
+
             var sections = new List<DeviceElementUse>();
             foreach (string isoDeviceElementID in isoDeviceElementIDs)
             {
                 DeviceHierarchyElement hierarchyElement = TaskDataMapper.DeviceElementHierarchies.GetMatchingElement(isoDeviceElementID);
                 if (hierarchyElement != null)
                 {
-                    DeviceElementUse deviceElementUse = null;
-                    List<WorkingData> workingDatas = new List<WorkingData>();
-
                     //Get the relevant DeviceElementConfiguration
-                    int adaptDeviceElementId = TaskDataMapper.InstanceIDMap.GetADAPTID(isoDeviceElementID).Value;
+                    int? adaptDeviceElementId = TaskDataMapper.InstanceIDMap.GetADAPTID(isoDeviceElementID);
                     DeviceElement adaptDeviceElement = DataModel.Catalog.DeviceElements.SingleOrDefault(d => d.Id.ReferenceId == adaptDeviceElementId);
                     if (adaptDeviceElement != null)
                     {
@@ -55,33 +89,29 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                             order = hierarchyElement.Parent.Order;
                         }
 
-                        deviceElementUse = sections.FirstOrDefault(d => d.DeviceConfigurationId == config.Id.ReferenceId);
+                        List<WorkingData> workingDatas = new List<WorkingData>();
+                        DeviceElementUse deviceElementUse = sections.FirstOrDefault(d => d.DeviceConfigurationId == config.Id.ReferenceId);
                         if (deviceElementUse == null)
                         {
                             //Create the DeviceElementUse
-                            deviceElementUse = new DeviceElementUse();
-                            deviceElementUse.Depth = depth;
-                            deviceElementUse.Order = order;
-                            deviceElementUse.OperationDataId = operationDataId;
-                            deviceElementUse.DeviceConfigurationId = config.Id.ReferenceId;
-
-                            //Add Working Data for any data on this device element
-                            List<WorkingData> data = _workingDataMapper.Map(time, isoRecords, deviceElementUse, hierarchyElement, sections, isoProductAllocations);
-                            if (data.Any())
+                            deviceElementUse = new DeviceElementUse
                             {
-                                workingDatas.AddRange(data);
-                            }
+                                Depth = depth,
+                                Order = order,
+                                OperationDataId = operationDataId,
+                                DeviceConfigurationId = config.Id.ReferenceId
+                            };
                         }
                         else
                         {
                             workingDatas = deviceElementUse.GetWorkingDatas().ToList();
+                        }
 
-                            //Add Additional Working Data
-                            List<WorkingData> data = _workingDataMapper.Map(time, isoRecords, deviceElementUse, hierarchyElement, sections, isoProductAllocations);
-                            if (data.Any())
-                            {
-                                workingDatas.AddRange(data);
-                            }
+                        //Add Working Data for any data on this device element
+                        List<WorkingData> data = _workingDataMapper.Map(time, isoRecords, deviceElementUse, hierarchyElement, sections, isoProductAllocations);
+                        if (data.Any())
+                        {
+                            workingDatas.AddRange(data);
                         }
 
                         deviceElementUse.GetWorkingDatas = () => workingDatas;

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionMapper.cs
@@ -108,7 +108,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                         }
 
                         //Add Working Data for any data on this device element
-                        List<WorkingData> data = _workingDataMapper.Map(time, isoRecords, deviceElementUse, hierarchyElement, sections, isoProductAllocations);
+                        List<WorkingData> data = _workingDataMapper.Map(time, isoRecordsWithData, deviceElementUse, hierarchyElement, sections, isoProductAllocations);
                         if (data.Any())
                         {
                             workingDatas.AddRange(data);

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
@@ -91,19 +91,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         private void SetEnumeratedMeterValue(ISOSpatialRow isoSpatialRow, EnumeratedWorkingData meter, SpatialRecord spatialRecord)
         {
             var isoDataLogValue = _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId];
-            SpatialValue isoValue = null;
-            if (isoDataLogValue != null)
-            {
-                var tmp = isoSpatialRow.SpatialValuesById[isoDataLogValue.Index];
-                if (tmp != null)
-                {
-                    ISODataLogValue dlv = tmp.DataLogValue;
-                    if (dlv.DeviceElementIdRef.ReverseEquals(isoDataLogValue.DeviceElementIdRef))
-                    {
-                        isoValue = tmp;
-                    }
-                }
-            }
+            var isoValue = isoSpatialRow.SpatialValues.FirstOrDefault(v =>
+                    v.DataLogValue.ProcessDataIntDDI == isoDataLogValue.ProcessDataIntDDI &&
+                    v.DataLogValue.DeviceElementIdRef.ReverseEquals(isoDataLogValue.DeviceElementIdRef)
+                    );
             if (isoValue != null)
             {
                 var isoEnumeratedMeter = meter as ISOEnumeratedMeter;
@@ -123,19 +114,12 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             var dataLogValue = _workingDataMapper.DataLogValuesByWorkingDataID.ContainsKey(meter.Id.ReferenceId)
                 ? _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId]
                 : null;
-            SpatialValue isoValue = null;
-            if (dataLogValue != null && dataLogValue.ProcessDataIntDDI != 0xDFFE)
-            {
-                var tmp = isoSpatialRow.SpatialValuesById[dataLogValue.Index];
-                if (tmp != null)
-                {
-                    ISODataLogValue dlv = tmp.DataLogValue;
-                    if (dlv.DeviceElementIdRef.ReverseEquals(dataLogValue.DeviceElementIdRef))
-                    {
-                        isoValue = tmp;
-                    }
-                }
-            }
+            var isoValue = dataLogValue != null && dataLogValue.ProcessDataIntDDI != 0xDFEE
+                           ? isoSpatialRow.SpatialValues.FirstOrDefault(v =>
+                                v.DataLogValue.ProcessDataIntDDI == dataLogValue.ProcessDataIntDDI &&
+                                v.DataLogValue.DeviceElementIdRef.ReverseEquals(dataLogValue.DeviceElementIdRef)
+                                )
+                           : null;
 
             if (isoValue != null)
             {

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
@@ -20,6 +20,8 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         WorkingData ConvertToBaseType(WorkingData meter);
         Dictionary<int, ISODataLogValue> DataLogValuesByWorkingDataID { get; set; }
         Dictionary<int, string> ISODeviceElementIDsByWorkingDataID { get; set; }
+
+        IEnumerable<ISODataLogValue> GetDataLogValuesForDeviceElement(ISOTime time, DeviceHierarchyElement deviceElementHierarchy);
     }
 
     public class WorkingDataMapper : BaseMapper, IWorkingDataMapper
@@ -38,6 +40,13 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             _ddis = DdiLoader.Ddis;
             DataLogValuesByWorkingDataID = new Dictionary<int, ISODataLogValue>();
             ISODeviceElementIDsByWorkingDataID = new Dictionary<int, string>();
+        }
+
+        public IEnumerable<ISODataLogValue> GetDataLogValuesForDeviceElement(ISOTime time, DeviceHierarchyElement deviceElementHierarchy)
+        {
+            return time.DataLogValues.Where(dlv => dlv.DeviceElementIdRef == deviceElementHierarchy.DeviceElement.DeviceElementId ||  //DLV DET reference matches the primary DET for the ADAPT element
+                                                                             deviceElementHierarchy.MergedElements.Any(e => e.DeviceElementId == dlv.DeviceElementIdRef)) //DLV DET reference matches one of the merged DETs on the ADAPT element
+                                     .ToList();
         }
 
         public List<WorkingData> Map(ISOTime time,

--- a/ISOv4Plugin/ObjectModel/ISOSpatialRow.cs
+++ b/ISOv4Plugin/ObjectModel/ISOSpatialRow.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
 {
@@ -21,8 +20,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
         public uint? GpsUtcTime { get; set;  }
         public ushort? GpsUtcDate { get; set; }
         public DateTime? GpsUtcDateTime { get; set; }
-        public IEnumerable<SpatialValue> SpatialValues => SpatialValuesById.Where(x => x != null);
-        public SpatialValue[] SpatialValuesById { get; set; }
+        public List<SpatialValue> SpatialValues { get; set; }
 
         /// <summary>
         /// Merge SpatialValues from provided SpatialRow into this one.
@@ -36,36 +34,13 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
                 return this;
             }
 
-            SpatialValue[] mine = SpatialValuesById;
-            SpatialValue[] theirs = otherRow.SpatialValuesById;
-            if (theirs != null)
+            if (SpatialValues == null)
             {
-                if (mine == null)
-                {
-                    SpatialValuesById = theirs;
-                }
-                else
-                {
-                    if (theirs.Length > mine.Length)
-                    {
-                        var tmp = mine;
-                        mine = SpatialValuesById = theirs;
-                        for (int i = 0; i < tmp.Length; i++)
-                        {
-                            mine[i] = tmp[i];
-                        }
-                    }
-                    else
-                    {
-                        for (int i = 0; i < mine.Length && i < theirs.Length; i++)
-                        {
-                            if (mine[i] == null)
-                            {
-                                mine[i] = theirs[i];
-                            }
-                        }
-                    }
-                }
+                SpatialValues = new List<SpatialValue>();
+            }
+            if (otherRow.SpatialValues != null)
+            {
+                SpatialValues.AddRange(otherRow.SpatialValues);
             }
 
             return this;


### PR DESCRIPTION
Hi Andrew,

Thank you for creating a performance PR for ISO plugin. After looking at your PR I see two distinct parts: first is to use integer value of DDI to avoid constant conversion from string to integer in all LINQ predicates and second to cache spatial row values by id.

The first part works great and does significantly improve performance of processing large data sets. The second one doesn't improve performance that much. Upon analyzing the code to understand why it is slow, I realized that majority of time is spent reading binary files over and over again when mapping sections and creating working datas. For each of the working data in the same section, binary files are being read to find first rows that have value for that working data. That's where the majority of slowdown happens.

My changes (second commit of this PR) optimizes this by loading all rows from binary files once per each section. That does bring in improvement in processing of large datasets especially if some TLG files have exactly 255 DLVs (working data) in them.

Please let me know how you would like to proceed in getting this changes in your PR and eventually into ISO plugin repo.